### PR TITLE
Add football betting app skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.env

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "tipster-backend",
+  "version": "1.0.0",
+  "main": "server.js",
+  "type": "module",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "axios": "^1.6.8",
+    "cors": "^2.8.5",
+    "dotenv": "^16.3.1",
+    "express": "^4.18.2"
+  }
+}

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,0 +1,106 @@
+/**
+ * Simple Express backend for fetching football match odds.
+ *
+ * Install dependencies:
+ *   cd backend && npm install
+ *
+ * Start the server on port 4000:
+ *   npm start
+ *
+ * Requires .env file with API_FOOTBALL_KEY=<your api key>
+ */
+
+import express from 'express';
+import axios from 'axios';
+import cors from 'cors';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const app = express();
+app.use(cors());
+
+const API_KEY = process.env.API_FOOTBALL_KEY;
+const API_URL = 'https://v3.football.api-sports.io';
+
+const LEAGUES = [39, 140, 135, 78, 61]; // EPL, La Liga, Serie A, Bundesliga, Ligue 1
+
+const http = axios.create({
+  baseURL: API_URL,
+  headers: { 'x-apisports-key': API_KEY }
+});
+
+async function fetchMatches(from, to) {
+  const all = [];
+  for (const league of LEAGUES) {
+    const params = { league, from, to, timezone: 'UTC' };
+    const res = await http.get('/fixtures', { params });
+    for (const item of res.data.response) {
+      const match = {
+        league: item.league.name,
+        home: item.teams.home.name,
+        away: item.teams.away.name,
+        kickoff: item.fixture.date,
+        odds: {}
+      };
+      // fetch odds for fixture
+      try {
+        const oddsRes = await http.get('/odds', {
+          params: { fixture: item.fixture.id, bookmaker: 6 } // bookmaker 6: bet365
+        });
+        const bet = oddsRes.data.response[0]?.bookmakers[0]?.bets.find(b => b.name === 'Match Winner');
+        if (bet) {
+          for (const v of bet.values) {
+            match.odds[v.value] = v.odd;
+          }
+        }
+      } catch (e) {
+        // ignore odds errors
+      }
+      all.push(match);
+    }
+  }
+  return all;
+}
+
+function todayStr(offset = 0) {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() + offset);
+  return d.toISOString().slice(0, 10);
+}
+
+app.get('/matches-today', async (req, res) => {
+  try {
+    const data = await fetchMatches(todayStr(), todayStr());
+    res.json(data);
+  } catch (e) {
+    res.status(500).json({ error: 'Failed to fetch matches' });
+  }
+});
+
+app.get('/matches-tomorrow', async (req, res) => {
+  try {
+    const date = todayStr(1);
+    const data = await fetchMatches(date, date);
+    res.json(data);
+  } catch (e) {
+    res.status(500).json({ error: 'Failed to fetch matches' });
+  }
+});
+
+app.get('/matches-week', async (req, res) => {
+  try {
+    const start = todayStr();
+    const end = todayStr(7);
+    const data = await fetchMatches(start, end);
+    res.json(data);
+  } catch (e) {
+    res.status(500).json({ error: 'Failed to fetch matches' });
+  }
+});
+
+const PORT = 4000;
+app.listen(PORT, () => {
+  console.log(`Backend running on port ${PORT}`);
+});
+

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "tipster-frontend",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "next dev -p 3000",
+    "build": "next build",
+    "start": "next start -p 3000"
+  },
+  "dependencies": {
+    "next": "13.4.12",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  }
+}

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -1,0 +1,92 @@
+/**
+ * Basic Next.js frontend to display betting info.
+ *
+ * Install dependencies:
+ *   cd frontend && npm install
+ *
+ * Start development server on port 3000:
+ *   npm run dev
+ */
+
+import { useState, useEffect } from 'react';
+
+const TABS = ['today', 'tomorrow', 'week'];
+
+export default function Home() {
+  const [active, setActive] = useState('today');
+  const [matches, setMatches] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [filter, setFilter] = useState('2.0');
+
+  useEffect(() => {
+    fetchData(active);
+  }, [active]);
+
+  async function fetchData(tab) {
+    setLoading(true);
+    const res = await fetch(`http://localhost:4000/matches-${tab}`);
+    const data = await res.json();
+    setMatches(data);
+    setLoading(false);
+  }
+
+  function calc(odd) {
+    const num = parseFloat(odd);
+    if (isNaN(num)) return '';
+    return (num * 0.95).toFixed(2);
+  }
+
+  const filtered = matches.filter(m => {
+    const home = parseFloat(m.odds['Home']);
+    return !filter || isNaN(home) || home < parseFloat(filter);
+  });
+
+  return (
+    <main style={{ padding: 20 }}>
+      <h1>Football Matches</h1>
+      <div>
+        {TABS.map(t => (
+          <button key={t} onClick={() => setActive(t)} disabled={t === active} style={{ marginRight: 5 }}>
+            {t.charAt(0).toUpperCase() + t.slice(1)}
+          </button>
+        ))}
+      </div>
+
+      <div style={{ marginTop: 10 }}>
+        <label>Filter home odds &lt; </label>
+        <input value={filter} onChange={e => setFilter(e.target.value)} style={{ width: 60 }} />
+      </div>
+
+      {loading ? (
+        <p>Loading...</p>
+      ) : (
+        <table border="1" cellPadding="4" style={{ marginTop: 10 }}>
+          <thead>
+            <tr>
+              <th>League</th>
+              <th>Home</th>
+              <th>Away</th>
+              <th>Kickoff</th>
+              <th>Odds (1X2)</th>
+              <th>Your Odds</th>
+              <th>Recommendation</th>
+            </tr>
+          </thead>
+          <tbody>
+            {filtered.map((m, i) => (
+              <tr key={i}>
+                <td>{m.league}</td>
+                <td>{m.home}</td>
+                <td>{m.away}</td>
+                <td>{new Date(m.kickoff).toLocaleString()}</td>
+                <td>{m.odds['Home']}/{m.odds['Draw']}/{m.odds['Away']}</td>
+                <td>{calc(m.odds['Home'])}/{calc(m.odds['Draw'])}/{calc(m.odds['Away'])}</td>
+                <td>{parseFloat(calc(m.odds['Home'])) > parseFloat(m.odds['Home']) ? 'Recommended' : ''}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </main>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -1,12 +1,5 @@
 {
-  "name": "frontend",
-  "version": "1.0.0",
-  "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
-  "description": ""
+  "name": "tipster-root",
+  "private": true,
+  "workspaces": ["backend", "frontend"]
 }


### PR DESCRIPTION
## Summary
- add backend Express server with endpoints for match odds
- add Next.js frontend page with tabbed match display and filtering
- setup workspaces and ignore node_modules

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6870ed9dcb20832ea2796b7c7cac4225