### PR TITLE
Implement basic Express backend

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,3 @@
+# Example environment variables for backend
+MONGODB_URI=mongodb://localhost:27017/mydb
+PORT=4000

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,0 +1,28 @@
+require('dotenv').config();
+const express = require('express');
+const mongoose = require('mongoose');
+const cors = require('cors');
+
+const app = express();
+
+// Enable CORS for the frontend running on localhost:3000
+app.use(cors({ origin: 'http://localhost:3000' }));
+
+// Parse JSON request bodies
+app.use(express.json());
+
+// Connect to MongoDB using Mongoose
+mongoose.connect(process.env.MONGODB_URI, {
+  useNewUrlParser: true,
+  useUnifiedTopology: true
+})
+.then(() => console.log('MongoDB connected'))
+.catch(err => console.error('MongoDB connection error:', err));
+
+// Simple test route
+app.get('/', (req, res) => {
+  res.send('API running');
+});
+
+const PORT = process.env.PORT || 4000;
+app.listen(PORT, () => console.log(`Server listening on port ${PORT}`));

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,10 +4,17 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node index.js"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "type": "commonjs"
+  "type": "commonjs",
+  "dependencies": {
+    "cors": "^2.8.5",
+    "dotenv": "^16.3.1",
+    "express": "^4.18.2",
+    "mongoose": "^7.6.1"
+  }
 }


### PR DESCRIPTION
## Summary
- add simple Express server that loads dotenv config
- enable CORS for `localhost:3000`
- connect to MongoDB via mongoose
- provide example environment file

## Testing
- `npm install --prefix backend` *(fails: 403 Forbidden due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_687618763c88832e9926de1720e514ed