### PR TITLE
Add API-Football service

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -15,6 +15,8 @@
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
-    "mongoose": "^7.6.1"
+    "mongoose": "^7.6.1",
+    "axios": "^1.6.0",
+    "node-cache": "^5.1.2"
   }
 }

--- a/backend/services/apiFootballService.js
+++ b/backend/services/apiFootballService.js
@@ -1,0 +1,48 @@
+const axios = require('axios');
+const NodeCache = require('node-cache');
+require('dotenv').config();
+
+const API_BASE_URL = 'https://v3.football.api-sports.io';
+const API_KEY = process.env.API_FOOTBALL_KEY;
+
+const cache = new NodeCache({ stdTTL: 600 }); // 10 minutes TTL
+
+const http = axios.create({
+  baseURL: API_BASE_URL,
+  headers: { 'x-apisports-key': API_KEY }
+});
+
+async function fetchWithCache(key, fetcher) {
+  const cached = cache.get(key);
+  if (cached) return cached;
+  const data = await fetcher();
+  cache.set(key, data);
+  return data;
+}
+
+async function getMatches(date) {
+  return fetchWithCache(`matches_${date}`, async () => {
+    const response = await http.get('/fixtures', { params: { date } });
+    return response.data;
+  });
+}
+
+async function getOdds(matchId) {
+  return fetchWithCache(`odds_${matchId}`, async () => {
+    const response = await http.get('/odds', { params: { fixture: matchId } });
+    return response.data;
+  });
+}
+
+async function getResults(date) {
+  return fetchWithCache(`results_${date}`, async () => {
+    const response = await http.get('/fixtures', { params: { date, status: 'FT' } });
+    return response.data;
+  });
+}
+
+module.exports = {
+  getMatches,
+  getOdds,
+  getResults
+};


### PR DESCRIPTION
## Summary
- add axios and node-cache to backend dependencies
- implement `apiFootballService` with basic caching functions

## Testing
- `npm test --workspace=backend` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68762b581b34832ebbb5b46c973ebc64