### PR TITLE
Implement REST API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,15 @@ This repository contains three Node.js projects managed as workspaces:
 - **telegram-bot** – Telegram bot service.
 
 Each folder contains its own `package.json` created with `npm init -y`. The source files are placeholders for further development.
+
+## Backend API
+
+The Express server in `backend` exposes the following endpoints:
+
+- `GET /matches-today` – return today's matches enriched with odds.
+- `GET /matches-tomorrow` – return tomorrow's matches and odds.
+- `GET /matches-week` – return matches with odds for the next seven days.
+- `GET /recommend?userId=ID` – return recommended bets for the given user based on their stored rules.
+- `POST /user/:id/rules` – save or update rules for a user.
+- `GET /user/:id/rules` – retrieve rules for a user.
+- `GET /results?date=YYYY-MM-DD` – fetch completed match results for the given date (defaults to today).

--- a/backend/models/UserRule.js
+++ b/backend/models/UserRule.js
@@ -1,0 +1,8 @@
+const mongoose = require('mongoose');
+
+const UserRuleSchema = new mongoose.Schema({
+  userId: { type: String, required: true, unique: true },
+  rules: { type: mongoose.Schema.Types.Mixed, default: {} }
+});
+
+module.exports = mongoose.model('UserRule', UserRuleSchema);


### PR DESCRIPTION
## Summary
- add `UserRule` mongoose model
- implement match, recommendation, rules and results endpoints
- document new backend endpoints in README

## Testing
- `npm test` *(fails: Missing script)*
- `npm --workspace backend test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68762f25429c832e9adbe36b9d871abb