### PR TITLE
Add example env files

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,18 @@ The bot connects to the backend API and supports several commands:
 - `/recommend` – get bet recommendations along with reasoning based on your saved rules.
 - `/results [YYYY-MM-DD]` – show final scores for the given day (defaults to today).
 - `/rules` – display current rules. Send `/rules {"minOdds":2}` to update your configuration using JSON.
+
+## Environment Setup
+
+Example `.env.example` files are provided in the `backend` and `telegram-bot` folders. Copy these files to `.env` and replace the placeholder values with your credentials.
+
+### backend/.env
+
+- `MONGODB_URI` – MongoDB connection string
+- `API_FOOTBALL_KEY` – API key from api-football
+- `PORT` – optional port for the Express server
+
+### telegram-bot/.env
+
+- `MONGODB_URI` – MongoDB connection string
+- `TELEGRAM_BOT_TOKEN` – token from BotFather (also exported as `BOT_TOKEN`)

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,3 +1,5 @@
 # Example environment variables for backend
-MONGODB_URI=mongodb://localhost:27017/mydb
+MONGODB_URI=mongodb://localhost:27017/tipster
+API_FOOTBALL_KEY=your-api-football-key
+# Optional port for the Express server
 PORT=4000

--- a/telegram-bot/.env.example
+++ b/telegram-bot/.env.example
@@ -1,0 +1,4 @@
+MONGODB_URI=mongodb://localhost:27017/tipster
+TELEGRAM_BOT_TOKEN=your-telegram-bot-token
+# The bot.js file expects BOT_TOKEN
+BOT_TOKEN=$TELEGRAM_BOT_TOKEN


### PR DESCRIPTION
## Summary
- add sample environment variables for backend and telegram-bot
- document new `.env.example` files in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6876763affcc832e9887e2096e86d78b