### PR TITLE
Add odds-only filter and Tailwind styles

### DIFF
--- a/frontend/components/RuleBuilder.js
+++ b/frontend/components/RuleBuilder.js
@@ -59,45 +59,49 @@ export default function RuleBuilder({ userId }) {
   }
 
   return (
-    <div className="rule-builder">
-      <h2>Rule Builder</h2>
-      <form onSubmit={handleSubmit}>
+    <div className="mb-8 border p-4">
+      <h2 className="text-xl font-semibold mb-2">Rule Builder</h2>
+      <form onSubmit={handleSubmit} className="space-y-2">
         <div>
-          <label>Min Odds: </label>
+          <label className="mr-2">Min Odds:</label>
           <input
             type="number"
             step="0.01"
             value={minOdds}
             onChange={(e) => setMinOdds(e.target.value)}
+            className="border px-1"
           />
         </div>
         <div>
-          <label>Max Odds: </label>
+          <label className="mr-2">Max Odds:</label>
           <input
             type="number"
             step="0.01"
             value={maxOdds}
             onChange={(e) => setMaxOdds(e.target.value)}
+            className="border px-1"
           />
         </div>
         <div>
-          <label>Value Score Threshold: </label>
+          <label className="mr-2">Value Score Threshold:</label>
           <input
             type="number"
             step="0.01"
             value={valueScore}
             onChange={(e) => setValueScore(e.target.value)}
+            className="border px-1"
           />
         </div>
         <div>
-          <label>League: </label>
+          <label className="mr-2">League:</label>
           <input
             type="text"
             value={league}
             onChange={(e) => setLeague(e.target.value)}
+            className="border px-1"
           />
         </div>
-        <button type="submit" disabled={loading}>
+        <button type="submit" disabled={loading} className="px-2 py-1 border">
           {loading ? 'Saving...' : 'Save Rules'}
         </button>
       </form>
@@ -111,28 +115,8 @@ export default function RuleBuilder({ userId }) {
           <li>No rules set</li>
         )}
       </ul>
-      {loadError && <p className="error">{loadError}</p>}
-      {status && <p className="status">{status}</p>}
-      <style jsx>{`
-        .rule-builder {
-          margin-bottom: 2rem;
-          border: 1px solid #ccc;
-          padding: 1rem;
-        }
-        form div {
-          margin-bottom: 0.5rem;
-        }
-        label {
-          margin-right: 0.5rem;
-        }
-        .error {
-          color: red;
-        }
-        .status {
-          margin-top: 0.5rem;
-          color: green;
-        }
-      `}</style>
+      {loadError && <p className="text-red-600">{loadError}</p>}
+      {status && <p className="text-green-600 mt-1">{status}</p>}
     </div>
   );
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,5 +12,10 @@
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "next": "15.4.2"
+  },
+  "devDependencies": {
+    "autoprefixer": "^10.4.14",
+    "postcss": "^8.4.31",
+    "tailwindcss": "^3.3.5"
   }
 }

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -14,6 +14,7 @@ export default function Home() {
   const [error, setError] = useState(null);
   const [leagueFilter, setLeagueFilter] = useState('');
   const [leagues, setLeagues] = useState([]);
+  const [withOddsOnly, setWithOddsOnly] = useState(false);
 
   useEffect(() => {
     async function fetchMatches() {
@@ -57,14 +58,16 @@ export default function Home() {
   };
 
   return (
-    <div className="container">
-      <nav className="nav">
-        <a href="/">Matches</a> | <a href="/recommendations">Recommendations</a>
+    <div className="p-4">
+      <nav className="mb-4">
+        <a href="/" className="mr-2">Matches</a>
+        |
+        <a href="/recommendations" className="ml-2">Recommendations</a>
       </nav>
-      <h1>Match List</h1>
+      <h1 className="text-center text-2xl font-semibold mb-4">Match List</h1>
       <RuleBuilder userId="1" />
-      <div className="filter">
-        <label htmlFor="league-filter">League: </label>
+      <div className="flex items-center gap-2 mb-4">
+        <label htmlFor="league-filter">League:</label>
         <input
           id="league-filter"
           type="text"
@@ -72,6 +75,7 @@ export default function Home() {
           value={leagueFilter}
           onChange={(e) => setLeagueFilter(e.target.value)}
           placeholder="Type or select league"
+          className="border px-1 py-0.5"
         />
         <datalist id="league-options">
           {leagues.map((l) => (
@@ -79,24 +83,39 @@ export default function Home() {
           ))}
         </datalist>
         {leagueFilter && (
-          <button className="clear" onClick={() => setLeagueFilter('')}>Clear</button>
+          <button
+            className="text-blue-600 underline"
+            onClick={() => setLeagueFilter('')}
+          >
+            Clear
+          </button>
         )}
+        <label className="flex items-center gap-1 ml-4">
+          <input
+            type="checkbox"
+            checked={withOddsOnly}
+            onChange={(e) => setWithOddsOnly(e.target.checked)}
+          />
+          Only with odds
+        </label>
       </div>
-      <div className="tabs">
+      <div className="flex justify-center gap-2 mb-4">
         {Object.entries(TABS).map(([key, label]) => (
           <button
             key={key}
             onClick={() => setTab(key)}
-            className={tab === key ? 'active' : ''}
+            className={`px-2 py-1 border rounded ${
+              tab === key ? 'bg-neutral-800 text-white' : 'bg-neutral-200'
+            }`}
           >
             {label}
           </button>
         ))}
       </div>
       {loading && <p>Loading...</p>}
-      {error && <p className="error">Error: {error}</p>}
+      {error && <p className="text-red-600">Error: {error}</p>}
       {!loading && !error && (
-        <table>
+        <table className="w-full border-collapse">
           <thead>
             <tr>
               <th>League</th>
@@ -117,107 +136,27 @@ export default function Home() {
                       .includes(leagueFilter.toLowerCase())
                   : true
               )
+              .filter((m) =>
+                withOddsOnly
+                  ? (m.odds?.[0]?.bookmakers?.[0]?.bets?.[0]?.values?.length ?? 0) > 0
+                  : true
+              )
               .map((m) => (
-              <tr key={m.fixture?.id}>
-                <td>{m.league?.name || '-'}</td>
-                <td>{m.teams?.home?.name || '-'}</td>
-                <td>{m.teams?.away?.name || '-'}</td>
-                <td>{m.fixture?.date ? new Date(m.fixture.date).toLocaleString() : '-'}</td>
-                <td>{renderOdds(m)}</td>
-                <td>N/A</td>
-                <td>N/A</td>
-              </tr>
-            ))}
+                <tr key={m.fixture?.id} className="border-b">
+                  <td className="p-1 border">{m.league?.name || '-'}</td>
+                  <td className="p-1 border">{m.teams?.home?.name || '-'}</td>
+                  <td className="p-1 border">{m.teams?.away?.name || '-'}</td>
+                  <td className="p-1 border">
+                    {m.fixture?.date ? new Date(m.fixture.date).toLocaleString() : '-'}
+                  </td>
+                  <td className="p-1 border">{renderOdds(m)}</td>
+                  <td className="p-1 border">N/A</td>
+                  <td className="p-1 border">N/A</td>
+                </tr>
+              ))}
           </tbody>
         </table>
       )}
-      <style jsx>{`
-        .container {
-          padding: 1rem;
-        }
-        .nav {
-          margin-bottom: 1rem;
-        }
-        h1 {
-          text-align: center;
-        }
-        .tabs {
-          display: flex;
-          justify-content: center;
-          margin-bottom: 1rem;
-        }
-        .tabs button {
-          margin: 0 0.5rem;
-          padding: 0.5rem 1rem;
-          border: none;
-          background: #f0f0f0;
-          cursor: pointer;
-        }
-        .tabs button.active {
-          background: #0070f3;
-          color: white;
-        }
-        .error {
-          color: red;
-        }
-        .filter {
-          margin-bottom: 1rem;
-          display: flex;
-          align-items: center;
-          gap: 0.5rem;
-        }
-        .filter input {
-          padding: 0.25rem;
-        }
-        .filter .clear {
-          background: transparent;
-          border: none;
-          color: #0070f3;
-          cursor: pointer;
-        }
-        table {
-          width: 100%;
-          border-collapse: collapse;
-        }
-        th, td {
-          border: 1px solid #ccc;
-          padding: 0.5rem;
-          text-align: left;
-        }
-        th {
-          background: #f0f0f0;
-        }
-        @media (max-width: 600px) {
-          table, thead, tbody, th, td, tr {
-            display: block;
-          }
-          tr {
-            margin-bottom: 1rem;
-          }
-          th {
-            display: none;
-          }
-          td {
-            position: relative;
-            padding-left: 50%;
-          }
-          td::before {
-            position: absolute;
-            left: 0;
-            width: 45%;
-            padding-left: 0.5rem;
-            font-weight: bold;
-            white-space: nowrap;
-          }
-          td:nth-of-type(1)::before { content: 'League'; }
-          td:nth-of-type(2)::before { content: 'Home'; }
-          td:nth-of-type(3)::before { content: 'Away'; }
-          td:nth-of-type(4)::before { content: 'Kickoff'; }
-          td:nth-of-type(5)::before { content: 'Odds'; }
-          td:nth-of-type(6)::before { content: 'Your Odds'; }
-          td:nth-of-type(7)::before { content: 'Recommendation'; }
-        }
-      `}</style>
     </div>
   );
 }

--- a/frontend/pages/recommendations.js
+++ b/frontend/pages/recommendations.js
@@ -76,15 +76,17 @@ export default function Recommendations() {
   };
 
   return (
-    <div className="container">
-      <nav className="nav">
-        <a href="/">Matches</a> | <a href="/recommendations">Recommendations</a>
+    <div className="p-4">
+      <nav className="mb-4">
+        <a href="/" className="mr-2">Matches</a>
+        |
+        <a href="/recommendations" className="ml-2">Recommendations</a>
       </nav>
-      <h1>Recommendations</h1>
+      <h1 className="text-center text-2xl font-semibold mb-4">Recommendations</h1>
       {loading && <p>Loading...</p>}
-      {error && <p className="error">Error: {error}</p>}
+      {error && <p className="text-red-600">Error: {error}</p>}
       {!loading && !error && (
-        <table>
+        <table className="w-full border-collapse">
           <thead>
             <tr>
               <th>League</th>
@@ -98,14 +100,14 @@ export default function Recommendations() {
           </thead>
           <tbody>
             {recs.map(r => (
-              <tr key={r.fixture?.id}>
-                <td>{r.league?.name || '-'}</td>
-                <td>{r.teams?.home?.name || '-'}</td>
-                <td>{r.teams?.away?.name || '-'}</td>
-                <td>{r.fixture?.date ? new Date(r.fixture.date).toLocaleString() : '-'}</td>
-                <td>{r.recommendedBet || 'Home Win'}</td>
-                <td>{renderOdds(r)}</td>
-                <td>{r.rationale || '-'}</td>
+              <tr key={r.fixture?.id} className="border-b">
+                <td className="p-1 border">{r.league?.name || '-'}</td>
+                <td className="p-1 border">{r.teams?.home?.name || '-'}</td>
+                <td className="p-1 border">{r.teams?.away?.name || '-'}</td>
+                <td className="p-1 border">{r.fixture?.date ? new Date(r.fixture.date).toLocaleString() : '-'}</td>
+                <td className="p-1 border">{r.recommendedBet || 'Home Win'}</td>
+                <td className="p-1 border">{renderOdds(r)}</td>
+                <td className="p-1 border">{r.rationale || '-'}</td>
               </tr>
             ))}
           </tbody>
@@ -117,32 +119,6 @@ export default function Recommendations() {
           <p>Wins: {accuracy.win} Losses: {accuracy.loss} ROI: {accuracy.roi}</p>
         </div>
       )}
-      <style jsx>{`
-        .container {
-          padding: 1rem;
-        }
-        .nav {
-          margin-bottom: 1rem;
-        }
-        h1 {
-          text-align: center;
-        }
-        table {
-          width: 100%;
-          border-collapse: collapse;
-        }
-        th, td {
-          border: 1px solid #ccc;
-          padding: 0.5rem;
-          text-align: left;
-        }
-        th {
-          background: #f0f0f0;
-        }
-        .error {
-          color: red;
-        }
-      `}</style>
     </div>
   );
 }

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -1,42 +1,12 @@
-:root {
-  --background: #ffffff;
-  --foreground: #171717;
-}
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
-}
-
-html,
+/* Simple monochrome theme */
 body {
-  max-width: 100vw;
-  overflow-x: hidden;
+  @apply bg-white text-neutral-900 dark:bg-neutral-900 dark:text-neutral-100;
 }
 
-body {
-  color: var(--foreground);
-  background: var(--background);
-  font-family: Arial, Helvetica, sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
-
-* {
-  box-sizing: border-box;
-  padding: 0;
-  margin: 0;
-}
-
-a {
-  color: inherit;
-  text-decoration: none;
-}
-
-@media (prefers-color-scheme: dark) {
-  html {
-    color-scheme: dark;
-  }
+nav a {
+  @apply text-blue-600 underline hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-200;
 }

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    "./pages/**/*.{js,ts,jsx,tsx}",
+    "./components/**/*.{js,ts,jsx,tsx}"
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- add odds-only checkbox filter on match list
- migrate frontend styling to Tailwind CSS with monochrome theme
- update package.json with Tailwind dependencies
- add Tailwind and PostCSS config files

## Testing
- `npm test` (backend) *(fails: Error: no test specified)*
- `npm test` (frontend) *(fails: missing script)*
- `npm test` (telegram-bot) *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687e10f22a64832e98e9b204b99de0f7