### PR TITLE
Display Myanmar bet info in match list

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -8,6 +8,7 @@ const {
   getResults
 } = require('./services/apiFootballService');
 const { recommendForUser } = require('./services/recommendationService');
+const { getMyanmarBet } = require('./utils/myanmarOdds');
 const UserRule = require('./models/UserRule');
 
 const app = express();
@@ -40,9 +41,10 @@ async function enrichMatchesWithOdds(matches) {
     matches.map(async (m) => {
       try {
         const odds = await getOdds(m.fixture.id);
-        return { ...m, odds: odds.response };
+        const myanmarBet = getMyanmarBet(odds.response);
+        return { ...m, odds: odds.response, myanmarBet };
       } catch (err) {
-        return { ...m, odds: [] };
+        return { ...m, odds: [], myanmarBet: null };
       }
     })
   );

--- a/backend/utils/myanmarOdds.js
+++ b/backend/utils/myanmarOdds.js
@@ -1,0 +1,50 @@
+const HANDICAP_TO_TYPE = {
+  '-1.5': '1-30%',
+  '-1.0': '1-50%',
+  '-0.5': '0.5-50%',
+  '0': 'Level Ball',
+  '-2.0': '2-50%',
+  '-2.5': '2-30%'
+};
+
+const MYANMAR_RULES = {
+  '1-30%': 'Win by 1 goal → 30% payout, win by 2+ goals → 100% payout, else lose.',
+  '1-50%': 'Win by 1 goal → 50% payout, win by 2+ goals → 100% payout, else lose.',
+  '0.5-50%': 'Win by any → 100%, draw → 50% refund, lose → lose.',
+  'Level Ball': 'Win → 100%, draw → refund, lose → lose.',
+  '2-50%': 'Win by 2 goals → 50% payout, win by 3+ goals → 100% payout, else lose.',
+  '2-30%': 'Win by 2 goals → 30% payout, win by 3+ goals → 100% payout, else lose.'
+};
+
+function mapHandicapToMyanmar(handicap, commission = 1.0) {
+  const type = HANDICAP_TO_TYPE[String(handicap)] || 'Unknown';
+  const rule = MYANMAR_RULES[type] || 'No Myanmar rule for this handicap.';
+  return { type, rule, payoutRate: Math.round(commission * 100) / 100 };
+}
+
+function extractHandicapFromOdds(odds) {
+  const bookmakers = odds?.[0]?.bookmakers || [];
+  for (const bookmaker of bookmakers) {
+    const bet = (bookmaker.bets || []).find(b =>
+      (b.name || '').toLowerCase().includes('asian handicap')
+    );
+    if (bet && bet.values && bet.values.length) {
+      const val = bet.values[0];
+      // value may be like "-1.5" or include home/away notation
+      const h = parseFloat(val.handicap || val.value || val.name);
+      if (!Number.isNaN(h)) return h;
+    }
+  }
+  return null;
+}
+
+function getMyanmarBet(odds, commission = 1.0) {
+  const handicap = extractHandicapFromOdds(odds);
+  if (handicap === null) return null;
+  const mapped = mapHandicapToMyanmar(handicap, commission);
+  return { handicap, ...mapped };
+}
+
+module.exports = {
+  getMyanmarBet
+};

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -57,6 +57,12 @@ export default function Home() {
       .join(', ') || 'N/A';
   };
 
+  const renderMyanmarBet = (match) => {
+    const bet = match.myanmarBet;
+    if (!bet) return 'N/A';
+    return `${bet.type} (${bet.handicap})`;
+  };
+
   return (
     <div className="p-4">
       <nav className="mb-4">
@@ -123,6 +129,7 @@ export default function Home() {
               <th>Away</th>
               <th>Kickoff</th>
               <th>Odds (1X2)</th>
+              <th>Myanmar Bet</th>
               <th>Your Odds</th>
               <th>Recommendation</th>
             </tr>
@@ -150,6 +157,7 @@ export default function Home() {
                     {m.fixture?.date ? new Date(m.fixture.date).toLocaleString() : '-'}
                   </td>
                   <td className="p-1 border">{renderOdds(m)}</td>
+                  <td className="p-1 border">{renderMyanmarBet(m)}</td>
                   <td className="p-1 border">N/A</td>
                   <td className="p-1 border">N/A</td>
                 </tr>

--- a/myanmar_bet_converter.py
+++ b/myanmar_bet_converter.py
@@ -1,0 +1,113 @@
+# -*- coding: utf-8 -*-
+"""Utility to convert Western Asian Handicap odds into Myanmar margin bets.
+
+This module provides functions to map common Asian Handicap lines to
+Myanmar-style bet types and return human readable rules and payout rates.
+
+Example:
+
+>>> bets = [
+...     {"team": "Liverpool", "handicap": -1.5, "odds": 1.92},
+...     {"team": "Chelsea", "handicap": -1.0, "odds": 2.01},
+... ]
+>>> convert_bets(bets)
+[
+    {
+        'team': 'Liverpool',
+        'handicap': -1.5,
+        'western_odds': 1.92,
+        'myanmar_type': '1-30%',
+        'myanmar_rule': 'Win by 1 goal → 30% payout, win by 2+ goals → 100% payout, else lose.',
+        'myanmar_payout_rate': 1.0
+    },
+    ...
+]
+"""
+
+from typing import Dict, List
+
+# Mapping of handicap lines to Myanmar margin bet types
+HANDICAP_TO_TYPE: Dict[float, str] = {
+    -1.5: "1-30%",
+    -1.0: "1-50%",
+    -0.5: "0.5-50%",
+    0.0: "Level Ball",
+    -2.0: "2-50%",
+    -2.5: "2-30%",
+}
+
+# Descriptions/rules for each Myanmar bet type
+MYANMAR_RULES: Dict[str, str] = {
+    "1-30%": "Win by 1 goal → 30% payout, win by 2+ goals → 100% payout, else lose.",
+    "1-50%": "Win by 1 goal → 50% payout, win by 2+ goals → 100% payout, else lose.",
+    "0.5-50%": "Win by any → 100%, draw → 50% refund, lose → lose.",
+    "Level Ball": "Win → 100%, draw → refund, lose → lose.",
+    "2-50%": "Win by 2 goals → 50% payout, win by 3+ goals → 100% payout, else lose.",
+    "2-30%": "Win by 2 goals → 30% payout, win by 3+ goals → 100% payout, else lose.",
+}
+
+
+def convert_bet(bet: Dict[str, float], commission: float = 1.0) -> Dict[str, object]:
+    """Convert a single bet dictionary to Myanmar style.
+
+    Parameters
+    ----------
+    bet : dict
+        Dictionary with keys ``team``, ``handicap`` and ``odds``.
+    commission : float, optional
+        Payout rate multiplier, by default ``1.0`` (no commission).
+
+    Returns
+    -------
+    dict
+        Dictionary describing the Myanmar style bet.
+    """
+    team = bet.get("team")
+    handicap = float(bet.get("handicap"))
+    odds = float(bet.get("odds"))
+
+    myanmar_type = HANDICAP_TO_TYPE.get(handicap, "Unknown")
+    myanmar_rule = MYANMAR_RULES.get(
+        myanmar_type, "No Myanmar rule for this handicap."
+    )
+
+    return {
+        "team": team,
+        "handicap": handicap,
+        "western_odds": odds,
+        "myanmar_type": myanmar_type,
+        "myanmar_rule": myanmar_rule,
+        "myanmar_payout_rate": round(commission, 2),
+    }
+
+
+def convert_bets(bets: List[Dict[str, float]], commission: float = 1.0) -> List[Dict[str, object]]:
+    """Convert a list of bets to Myanmar style.
+
+    Parameters
+    ----------
+    bets : list of dict
+        Each bet dictionary should contain ``team``, ``handicap`` and ``odds``.
+    commission : float, optional
+        Payout rate multiplier applied to all bets.
+
+    Returns
+    -------
+    list of dict
+        Each dictionary contains the Myanmar mapping and rule description.
+    """
+    return [convert_bet(bet, commission) for bet in bets]
+
+
+if __name__ == "__main__":
+    # Sample usage
+    sample_bets = [
+        {"team": "Liverpool", "handicap": -1.5, "odds": 1.92},
+        {"team": "Chelsea", "handicap": -1.0, "odds": 2.01},
+        {"team": "Man United", "handicap": 0, "odds": 2.0},
+        {"team": "Arsenal", "handicap": -2.5, "odds": 2.18},
+    ]
+
+    from pprint import pprint
+
+    pprint(convert_bets(sample_bets))


### PR DESCRIPTION
## Summary
- add Node utility to map Asian handicap odds to Myanmar bet info
- enrich backend match responses with `myanmarBet`
- show Myanmar bet column in the frontend match list table

## Testing
- `npm test` in `backend`
- `npm test` in `telegram-bot`
- `npm test` in `frontend` *(fails: Missing script)*
- `python3 myanmar_bet_converter.py`


------
https://chatgpt.com/codex/tasks/task_e_687e142d1708832eab0f11ca1882ab23