### PR TITLE
Handle Myanmar handicap extraction

### DIFF
--- a/backend/utils/myanmarOdds.js
+++ b/backend/utils/myanmarOdds.js
@@ -22,17 +22,24 @@ function mapHandicapToMyanmar(handicap, commission = 1.0) {
   return { type, rule, payoutRate: Math.round(commission * 100) / 100 };
 }
 
+function parseHandicap(str) {
+  if (str === undefined || str === null) return NaN;
+  if (typeof str === 'number') return parseFloat(str);
+  const match = String(str).match(/-?\d+(?:\.\d+)?/);
+  return match ? parseFloat(match[0]) : NaN;
+}
+
 function extractHandicapFromOdds(odds) {
   const bookmakers = odds?.[0]?.bookmakers || [];
   for (const bookmaker of bookmakers) {
-    const bet = (bookmaker.bets || []).find(b =>
+    const bet = (bookmaker.bets || []).find((b) =>
       (b.name || '').toLowerCase().includes('asian handicap')
     );
-    if (bet && bet.values && bet.values.length) {
-      const val = bet.values[0];
-      // value may be like "-1.5" or include home/away notation
-      const h = parseFloat(val.handicap || val.value || val.name);
-      if (!Number.isNaN(h)) return h;
+    if (bet && Array.isArray(bet.values)) {
+      for (const val of bet.values) {
+        const h = parseHandicap(val.handicap ?? val.value ?? val.name);
+        if (!Number.isNaN(h)) return h;
+      }
     }
   }
   return null;

--- a/myanmarOdds.test.js
+++ b/myanmarOdds.test.js
@@ -1,0 +1,27 @@
+const assert = require('assert');
+const { getMyanmarBet } = require('./backend/utils/myanmarOdds');
+
+function buildOdds(value) {
+  return [{
+    bookmakers: [{
+      bets: [{
+        name: 'Asian Handicap',
+        values: [typeof value === 'object' ? value : { value }]
+      }]
+    }]
+  }];
+}
+
+// simple numeric string
+let bet = getMyanmarBet(buildOdds('-1.5'));
+assert.strictEqual(bet.handicap, -1.5);
+
+// with leading text
+bet = getMyanmarBet(buildOdds({ value: 'Home -1.5' }));
+assert.strictEqual(bet.handicap, -1.5);
+
+// unknown handicap should still return number
+bet = getMyanmarBet(buildOdds('Away +0.25'));
+assert.strictEqual(bet.handicap, 0.25);
+
+console.log('All tests passed');


### PR DESCRIPTION
## Summary
- fix Myanmar handicap extraction logic
- add test coverage for Myanmar odds helper

## Testing
- `node myanmarOdds.test.js`


------
https://chatgpt.com/codex/tasks/task_e_687e2029ddc0832ea7bffcfa827ae616