### PR TITLE
Fix Myanmar bet display

### DIFF
--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import RuleBuilder from '../components/RuleBuilder';
+import { getMyanmarBet } from '../utils/myanmarOdds';
 
 const TABS = {
   today: 'Today',
@@ -75,7 +76,14 @@ export default function Home() {
   };
 
   const renderMyanmarBet = (match) => {
-    const bet = match.myanmarBet;
+    let bet = match.myanmarBet;
+    if (!bet && match.odds) {
+      try {
+        bet = getMyanmarBet(match.odds);
+      } catch (_) {
+        // ignore parsing errors
+      }
+    }
     if (!bet) return 'N/A';
     return `${bet.type} (${bet.handicap})`;
   };

--- a/frontend/utils/myanmarOdds.js
+++ b/frontend/utils/myanmarOdds.js
@@ -1,0 +1,53 @@
+const HANDICAP_TO_TYPE = {
+  '-1.5': '1-30%',
+  '-1.0': '1-50%',
+  '-0.5': '0.5-50%',
+  '0': 'Level Ball',
+  '-2.0': '2-50%',
+  '-2.5': '2-30%'
+};
+
+const MYANMAR_RULES = {
+  '1-30%': 'Win by 1 goal \u2192 30% payout, win by 2+ goals \u2192 100% payout, else lose.',
+  '1-50%': 'Win by 1 goal \u2192 50% payout, win by 2+ goals \u2192 100% payout, else lose.',
+  '0.5-50%': 'Win by any \u2192 100%, draw \u2192 50% refund, lose \u2192 lose.',
+  'Level Ball': 'Win \u2192 100%, draw \u2192 refund, lose \u2192 lose.',
+  '2-50%': 'Win by 2 goals \u2192 50% payout, win by 3+ goals \u2192 100% payout, else lose.',
+  '2-30%': 'Win by 2 goals \u2192 30% payout, win by 3+ goals \u2192 100% payout, else lose.'
+};
+
+function mapHandicapToMyanmar(handicap, commission = 1.0) {
+  const type = HANDICAP_TO_TYPE[String(handicap)] || 'Unknown';
+  const rule = MYANMAR_RULES[type] || 'No Myanmar rule for this handicap.';
+  return { type, rule, payoutRate: Math.round(commission * 100) / 100 };
+}
+
+function parseHandicap(str) {
+  if (str === undefined || str === null) return NaN;
+  if (typeof str === 'number') return parseFloat(str);
+  const match = String(str).match(/-?\d+(?:\.\d+)?/);
+  return match ? parseFloat(match[0]) : NaN;
+}
+
+function extractHandicapFromOdds(odds) {
+  const bookmakers = odds?.[0]?.bookmakers || [];
+  for (const bookmaker of bookmakers) {
+    const bet = (bookmaker.bets || []).find((b) =>
+      (b.name || '').toLowerCase().includes('asian handicap')
+    );
+    if (bet && Array.isArray(bet.values)) {
+      for (const val of bet.values) {
+        const h = parseHandicap(val.handicap ?? val.value ?? val.name);
+        if (!Number.isNaN(h)) return h;
+      }
+    }
+  }
+  return null;
+}
+
+export function getMyanmarBet(odds, commission = 1.0) {
+  const handicap = extractHandicapFromOdds(odds);
+  if (handicap === null) return null;
+  const mapped = mapHandicapToMyanmar(handicap, commission);
+  return { handicap, ...mapped };
+}


### PR DESCRIPTION
## Summary
- add a Myanmar odds utility to frontend
- compute Myanmar bet client-side if backend omits it

## Testing
- `node myanmarOdds.test.js`


------
https://chatgpt.com/codex/tasks/task_e_687e213a2ab0832e9e31a69eb6256378