### PR TITLE
Hide matches without odds by default

### DIFF
--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -15,7 +15,7 @@ export default function Home() {
   const [error, setError] = useState(null);
   const [leagueFilter, setLeagueFilter] = useState('');
   const [leagues, setLeagues] = useState([]);
-  const [withOddsOnly, setWithOddsOnly] = useState(false);
+  const [withOddsOnly, setWithOddsOnly] = useState(true);
 
   useEffect(() => {
     async function fetchMatches() {


### PR DESCRIPTION
## Summary
- default the `Only with odds` filter to ON

## Testing
- `node myanmarOdds.test.js`

------
https://chatgpt.com/codex/tasks/task_e_687fb3116d58832e93ad9cc6ab589ec7