### PR TITLE
Implement card-based match view and match details page

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -5,7 +5,8 @@ const cors = require('cors');
 const {
   getMatches,
   getOdds,
-  getResults
+  getResults,
+  getFixture
 } = require('./services/apiFootballService');
 const { recommendForUser } = require('./services/recommendationService');
 const { getMyanmarBet } = require('./utils/myanmarOdds');
@@ -93,6 +94,22 @@ app.get('/matches-week', async (req, res, next) => {
   } catch (err) {
     console.error(err);
     err.message = 'Unable to fetch this week\'s matches. Please try again later.';
+    next(err);
+  }
+});
+
+app.get('/match/:id', async (req, res, next) => {
+  const matchId = req.params.id;
+  try {
+    const fixtureData = await getFixture(matchId);
+    const fixture = fixtureData.response?.[0];
+    if (!fixture) return res.status(404).json({ error: 'Match not found' });
+    const oddsData = await getOdds(matchId);
+    fixture.odds = oddsData.response;
+    res.json(fixture);
+  } catch (err) {
+    console.error(err);
+    err.message = 'Failed to fetch match details. Please try again later.';
     next(err);
   }
 });

--- a/backend/services/apiFootballService.js
+++ b/backend/services/apiFootballService.js
@@ -41,8 +41,16 @@ async function getResults(date) {
   });
 }
 
+async function getFixture(matchId) {
+  return fetchWithCache(`fixture_${matchId}`, async () => {
+    const response = await http.get('/fixtures', { params: { id: matchId } });
+    return response.data;
+  });
+}
+
 module.exports = {
   getMatches,
   getOdds,
-  getResults
+  getResults,
+  getFixture
 };

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -146,51 +146,36 @@ export default function Home() {
       {loading && <p>Loading...</p>}
       {error && <p className="text-red-600">Error: {error}</p>}
       {!loading && !error && (
-        <table className="w-full border-collapse">
-          <thead>
-            <tr>
-              <th>League</th>
-              <th>Home</th>
-              <th>Away</th>
-              <th>Kickoff</th>
-              <th>Odds (1X2)</th>
-              <th>Asian Handicap</th>
-              <th>Myanmar Bet</th>
-              <th>Your Odds</th>
-              <th>Recommendation</th>
-            </tr>
-          </thead>
-          <tbody>
-            {matches
-              .filter((m) =>
-                leagueFilter
-                  ? (m.league?.name || '')
-                      .toLowerCase()
-                      .includes(leagueFilter.toLowerCase())
-                  : true
-              )
-              .filter((m) =>
-                withOddsOnly
-                  ? (m.odds?.[0]?.bookmakers?.[0]?.bets?.[0]?.values?.length ?? 0) > 0
-                  : true
-              )
-              .map((m) => (
-                <tr key={m.fixture?.id} className="border-b">
-                  <td className="p-1 border">{m.league?.name || '-'}</td>
-                  <td className="p-1 border">{m.teams?.home?.name || '-'}</td>
-                  <td className="p-1 border">{m.teams?.away?.name || '-'}</td>
-                  <td className="p-1 border">
-                    {m.fixture?.date ? new Date(m.fixture.date).toLocaleString() : '-'}
-                  </td>
-                  <td className="p-1 border">{renderOdds(m)}</td>
-                  <td className="p-1 border">{renderAsianHandicap(m)}</td>
-                  <td className="p-1 border">{renderMyanmarBet(m)}</td>
-                  <td className="p-1 border">N/A</td>
-                  <td className="p-1 border">N/A</td>
-                </tr>
-              ))}
-          </tbody>
-        </table>
+        <div className="grid gap-4 md:grid-cols-2">
+          {matches
+            .filter((m) =>
+              leagueFilter
+                ? (m.league?.name || '')
+                    .toLowerCase()
+                    .includes(leagueFilter.toLowerCase())
+                : true
+            )
+            .filter((m) =>
+              withOddsOnly
+                ? (m.odds?.[0]?.bookmakers?.[0]?.bets?.[0]?.values?.length ?? 0) > 0
+                : true
+            )
+            .map((m) => (
+              <div key={m.fixture?.id} className="border p-2 rounded shadow">
+                <h3 className="font-semibold">
+                  {m.teams?.home?.name || '-'} vs {m.teams?.away?.name || '-'}
+                </h3>
+                <p className="text-sm">{m.league?.name || '-'}</p>
+                <p className="text-sm">
+                  {m.fixture?.date ? new Date(m.fixture.date).toLocaleString() : '-'}
+                </p>
+                <p className="text-sm mb-1">Odds: {renderOdds(m)}</p>
+                <a href={`/match/${m.fixture?.id}`} className="text-blue-600 underline text-sm">
+                  View Details
+                </a>
+              </div>
+            ))}
+        </div>
       )}
     </div>
   );

--- a/frontend/pages/match/[id].js
+++ b/frontend/pages/match/[id].js
@@ -1,0 +1,74 @@
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+
+export default function MatchDetail() {
+  const router = useRouter();
+  const { id } = router.query;
+  const [match, setMatch] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (!id) return;
+    async function fetchMatch() {
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await fetch(`http://localhost:4000/match/${id}`);
+        let data;
+        if (!res.ok) {
+          const errData = await res.json().catch(() => ({}));
+          throw new Error(errData.error || 'Failed to fetch match');
+        } else {
+          data = await res.json();
+        }
+        setMatch(data);
+      } catch (err) {
+        setError(err.message || 'Something went wrong');
+      } finally {
+        setLoading(false);
+      }
+    }
+    fetchMatch();
+  }, [id]);
+
+  const renderBets = () => {
+    const bets = match?.odds?.[0]?.bookmakers?.[0]?.bets || [];
+    if (bets.length === 0) return <p>No odds available.</p>;
+    return (
+      <div className="space-y-4">
+        {bets.map((bet) => (
+          <div key={bet.id} className="border p-2 rounded">
+            <h3 className="font-semibold mb-1">{bet.name}</h3>
+            <ul className="list-disc ml-5">
+              {(bet.values || []).map((v, idx) => (
+                <li key={idx}>{`${v.handicap || v.value || v.name}: ${v.odd}`}</li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </div>
+    );
+  };
+
+  return (
+    <div className="p-4">
+      <nav className="mb-4">
+        <a href="/" className="mr-2">Matches</a>
+        |
+        <a href="/recommendations" className="ml-2">Recommendations</a>
+      </nav>
+      {loading && <p>Loading...</p>}
+      {error && <p className="text-red-600">Error: {error}</p>}
+      {match && (
+        <div>
+          <h1 className="text-2xl font-semibold mb-2">
+            {match.teams?.home?.name} vs {match.teams?.away?.name}
+          </h1>
+          <p className="mb-4">{new Date(match.fixture?.date).toLocaleString()}</p>
+          {renderBets()}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- expose new `getFixture` helper for API-Football
- add `/match/:id` route in backend to fetch fixture and odds
- switch matches page to card layout with links to match detail
- add new match detail page displaying all available bet types

## Testing
- `node myanmarOdds.test.js`

------
https://chatgpt.com/codex/tasks/task_e_687fb6e3b81c832eac0e1ae5612f6b3b