### PR TITLE
feat: add AI recommendation button

### DIFF
--- a/frontend/public/ai.svg
+++ b/frontend/public/ai.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+  <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2" fill="none"/>
+  <text x="12" y="16" text-anchor="middle" font-size="10" fill="currentColor">AI</text>
+</svg>


### PR DESCRIPTION
## Summary
- add AI recommendation button with icon
- show modal with match details and prompt for AI analysis

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (requires configuration; not executed)

------
https://chatgpt.com/codex/tasks/task_e_688f711296fc832e952d8df58e80fa9d