### PR TITLE
Use OpenAI to generate match predictions

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -17,6 +17,7 @@
     "express": "^4.18.2",
     "mongoose": "^7.6.1",
     "axios": "^1.6.0",
-    "node-cache": "^5.1.2"
+    "node-cache": "^5.1.2",
+    "openai": "^4.58.1"
   }
 }


### PR DESCRIPTION
## Summary
- Connect backend to OpenAI and expose `/ai-predict` to analyze match data
- Add OpenAI dependency
- Update match list page to call prediction endpoint and show AI recommendation

## Testing
- `npm test` (backend)
- `npm test` (frontend) *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688f7ca7a194832e927759abe27f69ef