### PR TITLE
Store AI match predictions and surface in UI and bot

### DIFF
--- a/backend/models/MatchPrediction.js
+++ b/backend/models/MatchPrediction.js
@@ -1,0 +1,9 @@
+const mongoose = require('mongoose');
+
+const MatchPredictionSchema = new mongoose.Schema({
+  fixtureId: { type: Number, unique: true, required: true },
+  prediction: { type: String, required: true },
+  createdAt: { type: Date, default: Date.now }
+});
+
+module.exports = mongoose.model('MatchPrediction', MatchPredictionSchema);

--- a/backend/services/predictionService.js
+++ b/backend/services/predictionService.js
@@ -1,0 +1,43 @@
+const OpenAI = require('openai');
+const MatchPrediction = require('../models/MatchPrediction');
+const openaiKey = process.env.OPENAI_API_KEY;
+const openai = openaiKey ? new OpenAI({ apiKey: openaiKey }) : null;
+
+function summarizeOdds(match) {
+  const values =
+    match?.odds?.[0]?.bookmakers?.[0]?.bets?.[0]?.values || [];
+  return values
+    .map((v) => `${v.value || v.name}: ${v.odd}`)
+    .join(', ');
+}
+
+async function generatePrediction(match) {
+  if (!openai) return '';
+  const home = match.teams?.home?.name || 'Home';
+  const away = match.teams?.away?.name || 'Away';
+  const odds = summarizeOdds(match) || 'odds unavailable';
+  const prompt = `Predict the likely outcome of the football match ${home} vs ${away} given odds: ${odds}. Provide a concise betting tip.`;
+  const resp = await openai.chat.completions.create({
+    model: 'gpt-3.5-turbo',
+    messages: [{ role: 'user', content: prompt }],
+  });
+  return resp.choices?.[0]?.message?.content?.trim() || '';
+}
+
+async function getOrCreatePrediction(match) {
+  const fixtureId = match?.fixture?.id;
+  if (!fixtureId) return '';
+  const existing = await MatchPrediction.findOne({ fixtureId });
+  if (existing) return existing.prediction;
+  const prediction = await generatePrediction(match);
+  if (!prediction) return '';
+  await MatchPrediction.create({ fixtureId, prediction });
+  return prediction;
+}
+
+async function getPrediction(fixtureId) {
+  const doc = await MatchPrediction.findOne({ fixtureId });
+  return doc ? doc.prediction : '';
+}
+
+module.exports = { getOrCreatePrediction, getPrediction };

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -267,7 +267,16 @@ export default function Home() {
                   {m.fixture?.date ? new Date(m.fixture.date).toLocaleString() : '-'}
                 </p>
                 <p className="text-sm mb-1">Odds: {renderOdds(m)}</p>
-                {expandedMatches[m.fixture?.id] && renderAllOdds(m)}
+                {expandedMatches[m.fixture?.id] && (
+                  <div>
+                    {m.aiPrediction && (
+                      <p className="italic mb-2">
+                        AI Prediction: {m.aiPrediction}
+                      </p>
+                    )}
+                    {renderAllOdds(m)}
+                  </div>
+                )}
               </div>
             ))}
         </div>

--- a/frontend/pages/match/[id].js
+++ b/frontend/pages/match/[id].js
@@ -71,6 +71,11 @@ export default function MatchDetail() {
             {match.teams?.home?.name} vs {match.teams?.away?.name}
           </h1>
           <p className="mb-4">{new Date(match.fixture?.date).toLocaleString()}</p>
+          {match.aiPrediction && (
+            <p className="mb-4 italic">
+              AI Prediction: {match.aiPrediction}
+            </p>
+          )}
           {renderBets()}
         </div>
       )}


### PR DESCRIPTION
## Summary
- generate and cache AI match predictions in MongoDB
- expose predictions via match endpoints and show in frontend
- telegram bot replies with stored predictions for matches

## Testing
- `node myanmarOdds.test.js`
- `npm test` (backend) *(fails: no test specified)*
- `npm test` (telegram-bot) *(fails: no test specified)*
- `npm test` (frontend) *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6891d4b3485c832e8c8c50416a80f0e7