### PR TITLE
feat: move rule builder to its own tab

### DIFF
--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -1,5 +1,4 @@
 import { useState, useEffect } from 'react';
-import RuleBuilder from '../components/RuleBuilder';
 import { getMyanmarBet } from '../utils/myanmarOdds';
 
 const TABS = {
@@ -171,10 +170,11 @@ export default function Home() {
       <nav className="mb-4">
         <a href="/" className="mr-2">Matches</a>
         |
-        <a href="/recommendations" className="ml-2">Recommendations</a>
+        <a href="/recommendations" className="mx-2">Recommendations</a>
+        |
+        <a href="/rule-builder" className="ml-2">Rule Builder</a>
       </nav>
       <h1 className="text-center text-2xl font-semibold mb-4">Match List</h1>
-      <RuleBuilder userId="1" />
       <div className="flex items-center gap-2 mb-4">
         <label htmlFor="league-filter">League:</label>
         <input

--- a/frontend/pages/recommendations.js
+++ b/frontend/pages/recommendations.js
@@ -80,7 +80,9 @@ export default function Recommendations() {
       <nav className="mb-4">
         <a href="/" className="mr-2">Matches</a>
         |
-        <a href="/recommendations" className="ml-2">Recommendations</a>
+        <a href="/recommendations" className="mx-2">Recommendations</a>
+        |
+        <a href="/rule-builder" className="ml-2">Rule Builder</a>
       </nav>
       <h1 className="text-center text-2xl font-semibold mb-4">Recommendations</h1>
       {loading && <p>Loading...</p>}

--- a/frontend/pages/rule-builder.js
+++ b/frontend/pages/rule-builder.js
@@ -1,0 +1,17 @@
+import RuleBuilder from '../components/RuleBuilder';
+
+export default function RuleBuilderPage() {
+  return (
+    <div className="p-4">
+      <nav className="mb-4">
+        <a href="/" className="mr-2">Matches</a>
+        |
+        <a href="/recommendations" className="mx-2">Recommendations</a>
+        |
+        <a href="/rule-builder" className="ml-2">Rule Builder</a>
+      </nav>
+      <h1 className="text-center text-2xl font-semibold mb-4">Rule Builder</h1>
+      <RuleBuilder userId="1" />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- remove RuleBuilder from the default matches page
- add navigation link and dedicated Rule Builder page

## Testing
- `npm test --prefix frontend` *(fails: Missing script "test")*
- `npm run lint --prefix frontend` *(fails: interactive setup required)*
- `node myanmarOdds.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68921f2b6618832e971b6786134bf1fe