### PR TITLE
Add prediction refresh endpoint and UI

### DIFF
--- a/backend/services/predictionService.js
+++ b/backend/services/predictionService.js
@@ -40,4 +40,17 @@ async function getPrediction(fixtureId) {
   return doc ? doc.prediction : '';
 }
 
-module.exports = { getOrCreatePrediction, getPrediction };
+async function refreshPrediction(match) {
+  const fixtureId = match?.fixture?.id;
+  if (!fixtureId) return '';
+  const prediction = await generatePrediction(match);
+  if (!prediction) return '';
+  await MatchPrediction.findOneAndUpdate(
+    { fixtureId },
+    { prediction, createdAt: new Date() },
+    { upsert: true }
+  );
+  return prediction;
+}
+
+module.exports = { getOrCreatePrediction, getPrediction, refreshPrediction };

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -165,6 +165,30 @@ export default function Home() {
     setAiError(null);
   };
 
+  const handleRefreshPrediction = async (e, fixtureId) => {
+    e.stopPropagation();
+    try {
+      const res = await fetch(
+        `http://localhost:4000/match/${fixtureId}/refresh-prediction`,
+        { method: 'POST' }
+      );
+      let data;
+      if (!res.ok) {
+        const errData = await res.json().catch(() => ({}));
+        throw new Error(errData.error || 'Failed to refresh prediction');
+      } else {
+        data = await res.json();
+      }
+      setMatches((prev) =>
+        prev.map((m) =>
+          m.fixture?.id === fixtureId ? { ...m, aiPrediction: data.prediction } : m
+        )
+      );
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
   return (
     <div className="p-4">
       <nav className="mb-4">
@@ -269,11 +293,15 @@ export default function Home() {
                 <p className="text-sm mb-1">Odds: {renderOdds(m)}</p>
                 {expandedMatches[m.fixture?.id] && (
                   <div>
-                    {m.aiPrediction && (
-                      <p className="italic mb-2">
-                        AI Prediction: {m.aiPrediction}
-                      </p>
-                    )}
+                    <p className="italic mb-2">
+                      AI Prediction: {m.aiPrediction || 'N/A'}
+                      <button
+                        className="ml-2 text-blue-600 underline"
+                        onClick={(e) => handleRefreshPrediction(e, m.fixture.id)}
+                      >
+                        Refresh
+                      </button>
+                    </p>
                     {renderAllOdds(m)}
                   </div>
                 )}

--- a/frontend/pages/match/[id].js
+++ b/frontend/pages/match/[id].js
@@ -32,6 +32,25 @@ export default function MatchDetail() {
     fetchMatch();
   }, [id]);
 
+  const refreshPrediction = async () => {
+    try {
+      const res = await fetch(
+        `http://localhost:4000/match/${id}/refresh-prediction`,
+        { method: 'POST' }
+      );
+      let data;
+      if (!res.ok) {
+        const errData = await res.json().catch(() => ({}));
+        throw new Error(errData.error || 'Failed to refresh prediction');
+      } else {
+        data = await res.json();
+      }
+      setMatch((prev) => ({ ...prev, aiPrediction: data.prediction }));
+    } catch (err) {
+      setError(err.message || 'Failed to refresh prediction');
+    }
+  };
+
   const renderBets = () => {
     const bookmakers = match?.odds?.[0]?.bookmakers || [];
     if (bookmakers.length === 0) return <p>No odds available.</p>;
@@ -71,11 +90,15 @@ export default function MatchDetail() {
             {match.teams?.home?.name} vs {match.teams?.away?.name}
           </h1>
           <p className="mb-4">{new Date(match.fixture?.date).toLocaleString()}</p>
-          {match.aiPrediction && (
-            <p className="mb-4 italic">
-              AI Prediction: {match.aiPrediction}
-            </p>
-          )}
+          <p className="mb-4 italic">
+            AI Prediction: {match.aiPrediction || 'N/A'}
+            <button
+              className="ml-2 text-blue-600 underline"
+              onClick={refreshPrediction}
+            >
+              Refresh
+            </button>
+          </p>
           {renderBets()}
         </div>
       )}


### PR DESCRIPTION
## Summary
- add service and endpoint to regenerate match predictions
- allow match list and detail pages to refresh AI predictions on demand

## Testing
- `npm test` (backend) *(fails: Error: no test specified)*
- `npm test` (frontend) *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_6892213f2e18832e86dda59464c2cac5