### PR TITLE
feat: allow admin match predictions

### DIFF
--- a/backend/models/MatchPrediction.js
+++ b/backend/models/MatchPrediction.js
@@ -2,7 +2,8 @@ const mongoose = require('mongoose');
 
 const MatchPredictionSchema = new mongoose.Schema({
   fixtureId: { type: Number, unique: true, required: true },
-  prediction: { type: String, required: true },
+  prediction: { type: String, default: '' },
+  human: { type: String, default: '' },
   createdAt: { type: Date, default: Date.now }
 });
 

--- a/frontend/pages/admin.js
+++ b/frontend/pages/admin.js
@@ -1,0 +1,144 @@
+import { useState, useEffect } from 'react';
+
+const TABS = {
+  today: 'Today',
+  tomorrow: 'Tomorrow',
+  week: 'This Week',
+};
+
+export default function Admin() {
+  const [tab, setTab] = useState('today');
+  const [matches, setMatches] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [expandedMatches, setExpandedMatches] = useState({});
+  const [inputs, setInputs] = useState({});
+
+  useEffect(() => {
+    async function fetchMatches() {
+      setLoading(true);
+      setError(null);
+      try {
+        const endpoint = tab === 'week' ? 'matches-week' : `matches-${tab}`;
+        const res = await fetch(`http://localhost:4000/${endpoint}`);
+        if (!res.ok) {
+          const errData = await res.json().catch(() => ({}));
+          throw new Error(errData.error || 'Failed to fetch matches');
+        }
+        const data = await res.json();
+        setMatches(Array.isArray(data) ? data : []);
+      } catch (err) {
+        setError(err.message || 'Something went wrong');
+      } finally {
+        setLoading(false);
+      }
+    }
+    fetchMatches();
+  }, [tab]);
+
+  const handleInputChange = (id, value) => {
+    setInputs((prev) => ({ ...prev, [id]: value }));
+  };
+
+  const handleSave = async (e, fixtureId) => {
+    e.stopPropagation();
+    const prediction = inputs[fixtureId];
+    try {
+      const res = await fetch(`http://localhost:4000/match/${fixtureId}/human-prediction`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ prediction }),
+      });
+      if (!res.ok) {
+        const errData = await res.json().catch(() => ({}));
+        throw new Error(errData.error || 'Failed to save prediction');
+      }
+      const data = await res.json();
+      setMatches((prev) =>
+        prev.map((m) =>
+          m.fixture?.id === fixtureId
+            ? { ...m, humanPrediction: data.humanPrediction }
+            : m
+        )
+      );
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const renderOdds = (match) => {
+    const values = match.odds?.[0]?.bookmakers?.[0]?.bets?.[0]?.values || [];
+    return values.map((v) => `${v.value || v.name}: ${v.odd}`).join(', ') || 'N/A';
+  };
+
+  return (
+    <div className="p-4">
+      <nav className="mb-4">
+        <a href="/" className="mr-2">Matches</a>
+        |
+        <a href="/recommendations" className="mx-2">Recommendations</a>
+        |
+        <a href="/rule-builder" className="ml-2">Rule Builder</a>
+        |
+        <a href="/admin" className="ml-2">Admin</a>
+      </nav>
+      <h1 className="text-center text-2xl font-semibold mb-4">Admin Predictions</h1>
+      <div className="flex justify-center gap-2 mb-4">
+        {Object.entries(TABS).map(([key, label]) => (
+          <button
+            key={key}
+            onClick={() => setTab(key)}
+            className={`px-2 py-1 border rounded ${
+              tab === key ? 'bg-neutral-800 text-white' : 'bg-neutral-200'
+            }`}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+      {loading && <p>Loading...</p>}
+      {error && <p className="text-red-600">Error: {error}</p>}
+      {!loading && !error && (
+        <div className="grid gap-4 md:grid-cols-2">
+          {matches.map((m) => (
+            <div
+              key={m.fixture?.id}
+              className="border p-2 rounded shadow cursor-pointer"
+              onClick={() =>
+                setExpandedMatches((prev) => ({
+                  ...prev,
+                  [m.fixture?.id]: !prev[m.fixture?.id],
+                }))
+              }
+            >
+              <h3 className="font-semibold">
+                {m.teams?.home?.name || '-'} vs {m.teams?.away?.name || '-'}
+              </h3>
+              <p className="text-sm">
+                {m.fixture?.date ? new Date(m.fixture.date).toLocaleString() : '-'}
+              </p>
+              <p className="text-sm mb-1">Odds: {renderOdds(m)}</p>
+              {expandedMatches[m.fixture?.id] && (
+                <div>
+                  <p className="italic mb-2">AI Prediction: {m.aiPrediction || 'N/A'}</p>
+                  <p className="italic mb-2">Human Prediction: {m.humanPrediction || 'N/A'}</p>
+                  <textarea
+                    className="w-full border p-1 mb-2"
+                    value={inputs[m.fixture?.id] ?? m.humanPrediction ?? ''}
+                    onChange={(e) => handleInputChange(m.fixture?.id, e.target.value)}
+                  />
+                  <button
+                    className="px-2 py-1 border rounded"
+                    onClick={(e) => handleSave(e, m.fixture.id)}
+                  >
+                    Save
+                  </button>
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -197,6 +197,8 @@ export default function Home() {
         <a href="/recommendations" className="mx-2">Recommendations</a>
         |
         <a href="/rule-builder" className="ml-2">Rule Builder</a>
+        |
+        <a href="/admin" className="ml-2">Admin</a>
       </nav>
       <h1 className="text-center text-2xl font-semibold mb-4">Match List</h1>
       <div className="flex items-center gap-2 mb-4">
@@ -301,6 +303,9 @@ export default function Home() {
                       >
                         Refresh
                       </button>
+                    </p>
+                    <p className="italic mb-2">
+                      Human Prediction: {m.humanPrediction || 'N/A'}
                     </p>
                     {renderAllOdds(m)}
                   </div>

--- a/frontend/pages/match/[id].js
+++ b/frontend/pages/match/[id].js
@@ -99,6 +99,9 @@ export default function MatchDetail() {
               Refresh
             </button>
           </p>
+          <p className="mb-4 italic">
+            Human Prediction: {match.humanPrediction || 'N/A'}
+          </p>
           {renderBets()}
         </div>
       )}

--- a/telegram-bot/bot.js
+++ b/telegram-bot/bot.js
@@ -52,7 +52,11 @@ function formatOdds(match) {
 }
 
 function formatPrediction(match) {
-  return match.aiPrediction || 'N/A';
+  const ai = match.aiPrediction || 'N/A';
+  const human = match.humanPrediction
+    ? `\nHuman: ${match.humanPrediction}`
+    : '';
+  return `AI: ${ai}${human}`;
 }
 
 // Lightweight intent extraction with OpenAI for date/teams


### PR DESCRIPTION
## Summary
- add optional human prediction field to match predictions
- expose endpoints and UI for admins to manage human predictions
- show human predictions below AI predictions across web and telegram bot

## Testing
- `cd backend && npm test`
- `cd frontend && npm test` *(fails: Missing script: "test")*
- `cd telegram-bot && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893654a363c832ebeb4db90bab1252a