### PR TITLE
Render AI predictions with markdown formatting

### DIFF
--- a/frontend/components/Markdown.js
+++ b/frontend/components/Markdown.js
@@ -1,0 +1,14 @@
+import { useMemo } from 'react';
+
+export default function Markdown({ text }) {
+  const html = useMemo(() => {
+    if (!text) return '';
+    return text
+      .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+      .replace(/\*(.+?)\*/g, '<em>$1</em>')
+      .replace(/`([^`]+)`/g, '<code>$1</code>')
+      .replace(/\n/g, '<br />');
+  }, [text]);
+
+  return <span dangerouslySetInnerHTML={{ __html: html }} />;
+}

--- a/frontend/pages/admin.js
+++ b/frontend/pages/admin.js
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import Markdown from '../components/Markdown';
 
 const TABS = {
   today: 'Today',
@@ -120,7 +121,10 @@ export default function Admin() {
               <p className="text-sm mb-1">Odds: {renderOdds(m)}</p>
               {expandedMatches[m.fixture?.id] && (
                 <div>
-                  <p className="italic mb-2">AI Prediction: {m.aiPrediction || 'N/A'}</p>
+                  <div className="italic mb-2">
+                    <div>AI Prediction:</div>
+                    <Markdown text={m.aiPrediction || 'N/A'} />
+                  </div>
                   <p className="italic mb-2">Human Prediction: {m.humanPrediction || 'N/A'}</p>
                   <textarea
                     className="w-full border p-1 mb-2"

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { getMyanmarBet } from '../utils/myanmarOdds';
+import Markdown from '../components/Markdown';
 
 const TABS = {
   today: 'Today',
@@ -295,15 +296,18 @@ export default function Home() {
                 <p className="text-sm mb-1">Odds: {renderOdds(m)}</p>
                 {expandedMatches[m.fixture?.id] && (
                   <div>
-                    <p className="italic mb-2">
-                      AI Prediction: {m.aiPrediction || 'N/A'}
-                      <button
-                        className="ml-2 text-blue-600 underline"
-                        onClick={(e) => handleRefreshPrediction(e, m.fixture.id)}
-                      >
-                        Refresh
-                      </button>
-                    </p>
+                    <div className="italic mb-2">
+                      <div>
+                        AI Prediction:
+                        <button
+                          className="ml-2 text-blue-600 underline"
+                          onClick={(e) => handleRefreshPrediction(e, m.fixture.id)}
+                        >
+                          Refresh
+                        </button>
+                      </div>
+                      <Markdown text={m.aiPrediction || 'N/A'} />
+                    </div>
                     <p className="italic mb-2">
                       Human Prediction: {m.humanPrediction || 'N/A'}
                     </p>

--- a/frontend/pages/match/[id].js
+++ b/frontend/pages/match/[id].js
@@ -1,5 +1,6 @@
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
+import Markdown from '../../components/Markdown';
 
 export default function MatchDetail() {
   const router = useRouter();
@@ -90,15 +91,18 @@ export default function MatchDetail() {
             {match.teams?.home?.name} vs {match.teams?.away?.name}
           </h1>
           <p className="mb-4">{new Date(match.fixture?.date).toLocaleString()}</p>
-          <p className="mb-4 italic">
-            AI Prediction: {match.aiPrediction || 'N/A'}
-            <button
-              className="ml-2 text-blue-600 underline"
-              onClick={refreshPrediction}
-            >
-              Refresh
-            </button>
-          </p>
+          <div className="mb-4 italic">
+            <div>
+              AI Prediction:
+              <button
+                className="ml-2 text-blue-600 underline"
+                onClick={refreshPrediction}
+              >
+                Refresh
+              </button>
+            </div>
+            <Markdown text={match.aiPrediction || 'N/A'} />
+          </div>
           <p className="mb-4 italic">
             Human Prediction: {match.humanPrediction || 'N/A'}
           </p>


### PR DESCRIPTION
## Summary
- add lightweight Markdown component to render AI predictions with basic formatting
- update match, list, and admin pages to display predictions using Markdown

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (setup prompt displayed, lint not run)


------
https://chatgpt.com/codex/tasks/task_e_68936d715330832eb5ee719f36708365