### PR TITLE
feat: add on-demand AI predictions

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -11,7 +11,6 @@ const {
 const { recommendForUser } = require('./services/recommendationService');
 const { getMyanmarBet } = require('./utils/myanmarOdds');
 const {
-  getOrCreatePrediction,
   getPrediction,
   refreshPrediction,
   setHumanPrediction
@@ -63,10 +62,7 @@ async function enrichMatchesWithOdds(matches) {
     try {
       const odds = await getOdds(m.fixture.id);
       const myanmarBet = getMyanmarBet(odds.response);
-      const { aiPrediction, humanPrediction } = await getOrCreatePrediction({
-        ...m,
-        odds: odds.response,
-      });
+      const { aiPrediction, humanPrediction } = await getPrediction(m.fixture.id);
       enriched.push({
         ...m,
         odds: odds.response,
@@ -152,10 +148,7 @@ app.get('/match/:id', async (req, res, next) => {
     if (!fixture) return res.status(404).json({ error: 'Match not found' });
     const oddsData = await getOdds(matchId);
     fixture.odds = oddsData.response;
-    const { aiPrediction, humanPrediction } = await getOrCreatePrediction({
-      ...fixture,
-      odds: oddsData.response,
-    });
+    const { aiPrediction, humanPrediction } = await getPrediction(matchId);
     fixture.aiPrediction = aiPrediction;
     fixture.humanPrediction = humanPrediction;
     res.json(fixture);

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -171,7 +171,7 @@ export default function Home() {
     setAiError(null);
   };
 
-  const handleRefreshPrediction = async (e, fixtureId) => {
+  const handleGetPrediction = async (e, fixtureId) => {
     e.stopPropagation();
     try {
       const res = await fetch(
@@ -181,7 +181,7 @@ export default function Home() {
       let data;
       if (!res.ok) {
         const errData = await res.json().catch(() => ({}));
-        throw new Error(errData.error || 'Failed to refresh prediction');
+        throw new Error(errData.error || 'Failed to fetch prediction');
       } else {
         data = await res.json();
       }
@@ -331,9 +331,11 @@ export default function Home() {
                             AI Prediction:
                             <button
                               className="ml-2 text-blue-600 underline"
-                              onClick={(e) => handleRefreshPrediction(e, m.fixture.id)}
+                              onClick={(e) => handleGetPrediction(e, m.fixture.id)}
                             >
-                              Refresh
+                              {m.aiPrediction
+                                ? 'Refresh AI Prediction'
+                                : 'Get AI Prediction'}
                             </button>
                           </div>
                           <Markdown text={m.aiPrediction || 'N/A'} />

--- a/frontend/pages/match/[id].js
+++ b/frontend/pages/match/[id].js
@@ -33,7 +33,7 @@ export default function MatchDetail() {
     fetchMatch();
   }, [id]);
 
-  const refreshPrediction = async () => {
+  const fetchPrediction = async () => {
     try {
       const res = await fetch(
         `http://localhost:4000/match/${id}/refresh-prediction`,
@@ -48,7 +48,7 @@ export default function MatchDetail() {
       }
       setMatch((prev) => ({ ...prev, aiPrediction: data.prediction }));
     } catch (err) {
-      setError(err.message || 'Failed to refresh prediction');
+      setError(err.message || 'Failed to fetch prediction');
     }
   };
 
@@ -96,9 +96,11 @@ export default function MatchDetail() {
               AI Prediction:
               <button
                 className="ml-2 text-blue-600 underline"
-                onClick={refreshPrediction}
+                onClick={fetchPrediction}
               >
-                Refresh
+                {match.aiPrediction
+                  ? 'Refresh AI Prediction'
+                  : 'Get AI Prediction'}
               </button>
             </div>
             <Markdown text={match.aiPrediction || 'N/A'} />


### PR DESCRIPTION
## Summary
- avoid auto-generating AI predictions when fetching matches
- add buttons to request AI predictions on demand
- rename refresh handlers for clarity

## Testing
- `node myanmarOdds.test.js`
- `npm test` (backend) *(fails: no test specified)*
- `npm test` (frontend) *(fails: missing script)*
- `npm run lint` *(fails: requires interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_689c6a970580832ea6801ad9ac0936c4