### PR TITLE
Add match caching and AI prediction refresh controls

### DIFF
--- a/backend/models/Match.js
+++ b/backend/models/Match.js
@@ -1,0 +1,9 @@
+const mongoose = require('mongoose');
+
+const MatchSchema = new mongoose.Schema({
+  date: { type: String, unique: true, required: true },
+  matches: { type: Array, default: [] },
+  updatedAt: { type: Date, default: Date.now }
+});
+
+module.exports = mongoose.model('Match', MatchSchema);


### PR DESCRIPTION
## Summary
- cache match lists and odds in MongoDB with optional refresh
- add refresh button to reload match list from API
- fetch AI predictions on demand per match card

## Testing
- `npm test` (backend) *(fails: Error: no test specified)*
- `npm test` (frontend) *(fails: Missing script: "test")*
- `npm run lint` (frontend) *(prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_689ca95c63d8832eb9405269335afa44