### PR TITLE
feat: add optional odds api provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Tipster
 
-Tipster is a small demo project that fetches football match data from the [API-Football](https://www.api-football.com/) service and provides simple betting recommendations.  The repository contains three Node.js based services:
+Tipster is a small demo project that fetches football match data from the [API-Football](https://www.api-football.com/) service or optionally from [The Odds API](https://the-odds-api.com/) based on configuration and provides simple betting recommendations.  The repository contains three Node.js based services:
 
-- **backend/** – Express API that queries API‑Football, stores user rules in MongoDB and exposes endpoints for matches, results and recommendations.
+- **backend/** – Express API that queries API‑Football or The Odds API, stores user rules in MongoDB and exposes endpoints for matches, results and recommendations.
 - **frontend/** – Next.js web client to browse matches and manage rules.
 - **telegram-bot/** – Telegram bot that delivers recommendations and match info via chat.
 
@@ -10,7 +10,7 @@ Tipster is a small demo project that fetches football match data from the [API-F
 
 - Node.js (version 18 or later is recommended)
 - A running MongoDB instance
-- API keys for API‑Football and Telegram (see the `.env.example` files)
+- API keys for API‑Football, The Odds API and Telegram (see the `.env.example` files)
 
 ## Getting Started
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,5 +1,11 @@
 # Example environment variables for backend
 MONGODB_URI=mongodb://localhost:27017/tipster
 API_FOOTBALL_KEY=your-api-football-key
+THE_ODDS_API_KEY=your-the-odds-api-key
+DATA_PROVIDER=api-football
+# Optional settings for The Odds API
+THE_ODDS_API_SPORT=soccer_epl
+THE_ODDS_API_REGION=uk
+THE_ODDS_API_MARKETS=h2h
 # Optional port for the Express server
 PORT=4000

--- a/backend/index.js
+++ b/backend/index.js
@@ -2,12 +2,12 @@ require('dotenv').config();
 const express = require('express');
 const mongoose = require('mongoose');
 const cors = require('cors');
-const {
-  getMatches,
-  getOdds,
-  getResults,
-  getFixture
-} = require('./services/apiFootballService');
+const DATA_PROVIDER = process.env.DATA_PROVIDER || 'api-football';
+const apiService =
+  DATA_PROVIDER === 'odds-api'
+    ? require('./services/oddsApiService')
+    : require('./services/apiFootballService');
+const { getMatches, getOdds, getResults, getFixture } = apiService;
 const { recommendForUser } = require('./services/recommendationService');
 const { getMyanmarBet } = require('./utils/myanmarOdds');
 const Match = require('./models/Match');

--- a/backend/services/oddsApiService.js
+++ b/backend/services/oddsApiService.js
@@ -1,0 +1,104 @@
+const axios = require('axios');
+const NodeCache = require('node-cache');
+require('dotenv').config();
+
+const API_BASE_URL = 'https://api.the-odds-api.com/v4';
+const API_KEY = process.env.THE_ODDS_API_KEY;
+const SPORT = process.env.THE_ODDS_API_SPORT || 'soccer_epl';
+const REGION = process.env.THE_ODDS_API_REGION || 'uk';
+const MARKETS = process.env.THE_ODDS_API_MARKETS || 'h2h';
+
+const cache = new NodeCache({ stdTTL: 600 });
+
+async function fetchWithCache(key, fetcher) {
+  const cached = cache.get(key);
+  if (cached) return cached;
+  const data = await fetcher();
+  cache.set(key, data);
+  return data;
+}
+
+function mapEvent(event) {
+  return {
+    fixture: {
+      id: event.id,
+      date: event.commence_time,
+    },
+    league: {
+      id: event.sport_key,
+      name: event.sport_title,
+    },
+    teams: {
+      home: { name: event.home_team },
+      away: { name: event.away_team },
+    },
+    odds: [
+      {
+        bookmakers: (event.bookmakers || []).map((bm) => ({
+          name: bm.title,
+          bets: (bm.markets || []).map((m) => ({
+            name: m.key,
+            values: (m.outcomes || []).map((o) => ({
+              name: o.name,
+              odd: o.price,
+              handicap: o.point,
+            })),
+          })),
+        })),
+      },
+    ],
+  };
+}
+
+async function fetchEvents() {
+  const response = await axios.get(`${API_BASE_URL}/sports/${SPORT}/odds`, {
+    params: {
+      apiKey: API_KEY,
+      regions: REGION,
+      markets: MARKETS,
+      dateFormat: 'iso',
+      oddsFormat: 'decimal',
+    },
+  });
+  return response.data || [];
+}
+
+async function getMatches(date) {
+  return fetchWithCache(`matches_${date}`, async () => {
+    const events = await fetchEvents();
+    const filtered = events.filter((e) =>
+      e.commence_time.startsWith(date)
+    );
+    return { response: filtered.map(mapEvent) };
+  });
+}
+
+async function getOdds(matchId) {
+  return fetchWithCache(`odds_${matchId}`, async () => {
+    const events = await fetchEvents();
+    const event = events.find((e) => e.id == matchId);
+    if (!event) return { response: [] };
+    return { response: [mapEvent(event).odds[0]] };
+  });
+}
+
+async function getResults(date) {
+  // The Odds API does not provide historical results.
+  return { response: [] };
+}
+
+async function getFixture(matchId) {
+  return fetchWithCache(`fixture_${matchId}`, async () => {
+    const events = await fetchEvents();
+    const event = events.find((e) => e.id == matchId);
+    if (!event) return { response: [] };
+    return { response: [mapEvent(event)] };
+  });
+}
+
+module.exports = {
+  getMatches,
+  getOdds,
+  getResults,
+  getFixture,
+};


### PR DESCRIPTION
## Summary
- integrate The Odds API alongside existing API-Football
- switch data provider via `DATA_PROVIDER` env var
- document new configuration variables

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689cb1c2bb88832ea874b1be4ff48863