### PR TITLE
Handle string fixture IDs in predictions

### DIFF
--- a/backend/models/MatchPrediction.js
+++ b/backend/models/MatchPrediction.js
@@ -1,7 +1,9 @@
 const mongoose = require('mongoose');
 
 const MatchPredictionSchema = new mongoose.Schema({
-  fixtureId: { type: Number, unique: true, required: true },
+  // Fixture IDs from different data providers can be numeric or
+  // alphanumeric (e.g. The Odds API). Store as string to accommodate both.
+  fixtureId: { type: String, unique: true, required: true },
   prediction: { type: String, default: '' },
   human: { type: String, default: '' },
   createdAt: { type: Date, default: Date.now }

--- a/backend/services/predictionService.js
+++ b/backend/services/predictionService.js
@@ -39,10 +39,11 @@ async function generatePrediction(match) {
 async function getOrCreatePrediction(match) {
   const fixtureId = match?.fixture?.id;
   if (!fixtureId) return { aiPrediction: '', humanPrediction: '' };
-  let doc = await MatchPrediction.findOne({ fixtureId });
+  const idStr = String(fixtureId);
+  let doc = await MatchPrediction.findOne({ fixtureId: idStr });
   if (!doc) {
     const prediction = await generatePrediction(match);
-    doc = await MatchPrediction.create({ fixtureId, prediction });
+    doc = await MatchPrediction.create({ fixtureId: idStr, prediction });
   }
   return {
     aiPrediction: doc.prediction || '',
@@ -51,7 +52,7 @@ async function getOrCreatePrediction(match) {
 }
 
 async function getPrediction(fixtureId) {
-  const doc = await MatchPrediction.findOne({ fixtureId });
+  const doc = await MatchPrediction.findOne({ fixtureId: String(fixtureId) });
   return {
     aiPrediction: doc?.prediction || '',
     humanPrediction: doc?.human || '',
@@ -61,7 +62,7 @@ async function getPrediction(fixtureId) {
 async function setHumanPrediction(fixtureId, humanPrediction) {
   if (!fixtureId) return '';
   const doc = await MatchPrediction.findOneAndUpdate(
-    { fixtureId },
+    { fixtureId: String(fixtureId) },
     { human: humanPrediction },
     { new: true, upsert: true }
   );
@@ -71,10 +72,11 @@ async function setHumanPrediction(fixtureId, humanPrediction) {
 async function refreshPrediction(match) {
   const fixtureId = match?.fixture?.id;
   if (!fixtureId) return '';
+  const idStr = String(fixtureId);
   const prediction = await generatePrediction(match);
   if (!prediction) return '';
   await MatchPrediction.findOneAndUpdate(
-    { fixtureId },
+    { fixtureId: idStr },
     { prediction, createdAt: new Date() },
     { upsert: true }
   );


### PR DESCRIPTION
## Summary
- Store MatchPrediction.fixtureId as a string to support alphanumeric IDs
- Normalize fixtureId usage in prediction service

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689cb90bb0ec832eac320caa49e73fae