### PR TITLE
fix: configure backend URL and token for bot

### DIFF
--- a/telegram-bot/.env.example
+++ b/telegram-bot/.env.example
@@ -1,5 +1,8 @@
 MONGODB_URI=mongodb://localhost:27017/tipster
+# Telegram bot token
+BOT_TOKEN=your-telegram-bot-token
+# Optional: the bot also falls back to TELEGRAM_BOT_TOKEN
 TELEGRAM_BOT_TOKEN=your-telegram-bot-token
-# The bot.js file expects BOT_TOKEN
-BOT_TOKEN=$TELEGRAM_BOT_TOKEN
 OPENAI_API_KEY=your-openai-api-key
+# Base URL for the backend API
+API_BASE_URL=http://localhost:4000


### PR DESCRIPTION
## Summary
- allow bot to read token from `BOT_TOKEN` or `TELEGRAM_BOT_TOKEN`
- make backend API URL configurable via `API_BASE_URL`
- document environment variables in `.env.example`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689d695a50ac832ebcfa18d775f45fa6