### PR TITLE
Handle non-JSON responses in intent extraction

### DIFF
--- a/telegram-bot/bot.js
+++ b/telegram-bot/bot.js
@@ -102,8 +102,14 @@ async function extractIntent(text) {
   }
   // Only parse first JSON object
   const jsonMatch = content.match(/{[\s\S]+}/);
-  if (jsonMatch) content = jsonMatch[0];
-  const intent = JSON.parse(content);
+  if (!jsonMatch) return null;
+  let intent;
+  try {
+    intent = JSON.parse(jsonMatch[0]);
+  } catch (err) {
+    console.error('Intent JSON parse error:', err);
+    return null;
+  }
   const genericWords = ['match', 'matches', 'game', 'games', 'for'];
   if (intent.teams && Array.isArray(intent.teams)) {
     intent.teams = intent.teams.filter(


### PR DESCRIPTION
## Summary
- avoid crashes when OpenAI response isn't valid JSON by safely parsing intent and returning null

## Testing
- `npm test` *(telegram-bot: no tests specified)*
- `npm test` *(backend: no tests specified)*
- `npm test` *(frontend: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_689d7d49c5f0832e80814e6eb8aa622e