### PR TITLE
Fetch Telegram bot match data from MongoDB

### DIFF
--- a/telegram-bot/models/Match.js
+++ b/telegram-bot/models/Match.js
@@ -1,0 +1,9 @@
+const mongoose = require('mongoose');
+
+const MatchSchema = new mongoose.Schema({
+  date: { type: String, unique: true, required: true },
+  matches: { type: Array, default: [] },
+  updatedAt: { type: Date, default: Date.now }
+});
+
+module.exports = mongoose.model('Match', MatchSchema);

--- a/telegram-bot/models/MatchPrediction.js
+++ b/telegram-bot/models/MatchPrediction.js
@@ -1,0 +1,10 @@
+const mongoose = require('mongoose');
+
+const MatchPredictionSchema = new mongoose.Schema({
+  fixtureId: { type: String, unique: true, required: true },
+  prediction: { type: String, default: '' },
+  human: { type: String, default: '' },
+  createdAt: { type: Date, default: Date.now }
+});
+
+module.exports = mongoose.model('MatchPrediction', MatchPredictionSchema);


### PR DESCRIPTION
## Summary
- update bot to read matches and predictions directly from MongoDB
- add Mongoose models for Match and MatchPrediction

## Testing
- `node myanmarOdds.test.js`
- `npm test --prefix telegram-bot` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689d840b3978832e88d40927cdf4265e