### PR TITLE
Fix team search to include away teams

### DIFF
--- a/telegram-bot/bot.js
+++ b/telegram-bot/bot.js
@@ -239,11 +239,13 @@ bot.on('message', async (msg) => {
       matches
     ) {
       matches = matches.filter((m) =>
-        intent.teams.every((team) =>
-          `${m.teams.home.name} ${m.teams.away.name}`
-            .toLowerCase()
-            .includes(team.toLowerCase())
-        )
+        intent.teams.every((team) => {
+          const t = team.toLowerCase();
+          return (
+            m.teams.home.name.toLowerCase().includes(t) ||
+            m.teams.away.name.toLowerCase().includes(t)
+          );
+        })
       );
     }
 


### PR DESCRIPTION
## Summary
- ensure natural language searches match both home and away teams in Telegram bot

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_689da23cfd8c832e91b5ddb932b24732