### PR TITLE
Support multiple sports in The Odds API

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -4,6 +4,7 @@ API_FOOTBALL_KEY=your-api-football-key
 THE_ODDS_API_KEY=your-the-odds-api-key
 DATA_PROVIDER=api-football
 # Optional settings for The Odds API
+# Multiple sports can be provided as a comma-separated list without spaces
 THE_ODDS_API_SPORT=soccer_epl
 THE_ODDS_API_REGION=uk
 THE_ODDS_API_MARKETS=h2h


### PR DESCRIPTION
## Summary
- handle comma-separated THE_ODDS_API_SPORT values and aggregate odds for each sport
- document multi-sport usage in backend .env example

## Testing
- `npm test` (fails: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_689db6e9ac54832eae9651b1f682da88