### PR TITLE
Increase OpenAI token limit

### DIFF
--- a/backend/services/predictionService.js
+++ b/backend/services/predictionService.js
@@ -27,7 +27,7 @@ async function generatePrediction(match) {
       model: 'gpt-4.1-mini',
       input: prompt,
       tools: [{ type: 'web_search' }],
-      max_output_tokens: 500,
+      max_output_tokens: 1000,
     });
     return resp.output_text?.trim() || '';
   } catch (err) {


### PR DESCRIPTION
## Summary
- prevent truncated AI predictions by increasing `max_output_tokens` to 1000

## Testing
- `npm test` (backend)
- `npm test` (frontend) *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689db8d42f90832e96b7e5a195268e40