### PR TITLE
Persist AI predictions across matches

### DIFF
--- a/frontend/pages/admin.js
+++ b/frontend/pages/admin.js
@@ -132,6 +132,7 @@ export default function Admin() {
                     <textarea
                       className="w-full border p-1 mb-2"
                       value={inputs[m.fixture?.id] ?? m.humanPrediction ?? ''}
+                      onClick={(e) => e.stopPropagation()}
                       onChange={(e) => handleInputChange(m.fixture?.id, e.target.value)}
                     />
                     <button


### PR DESCRIPTION
## Summary
- Stop Admin text area clicks from collapsing match cards
- Return and refresh AI predictions with match list endpoints

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint` (fails: requires ESLint configuration)

------
https://chatgpt.com/codex/tasks/task_e_689dbe139018832eaae8022a6e7629b8